### PR TITLE
Persist food changes across refreshes and to diary

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -1,3 +1,6 @@
+var foods = JSON.parse(localStorage.getItem('foodsList')) || [];
+var mealFoods = JSON.parse(localStorage.getItem('mealFoodsList')) || [];
+
 $('document').ready(function() {
   $(document.body).on('keyup', '.food-filter', function() {
     var input = $('input[name=food-name-filter]').val().toLowerCase();

--- a/lib/foods.js
+++ b/lib/foods.js
@@ -1,5 +1,6 @@
+var hackyCounter = 1;
+
 $('document').ready(function() {
-  var foods = JSON.parse(localStorage.getItem('foodsList')) || [];
   displayFoods(foods);
 
   $('#add-food').on('click', function() {
@@ -27,6 +28,7 @@ $('document').ready(function() {
     for (i = 0; i < foods.length; ++i) {
       if (foods[i]["name"] == foodNameToDelete) {
         foods.remove(i);
+        break;
       }
     }
     localStorage.setItem('foodsList', JSON.stringify(foods));
@@ -34,6 +36,8 @@ $('document').ready(function() {
 
   $(document.body).on('click', '.food-field', function() {
     var previousContents = $(this).html();
+    var foodNameToUpdate = $(this).parent('tr').children('td.food-name').text();
+
     $(this).html(
       "<input type='text' name='new-contents' value=" + previousContents + ">"
     );
@@ -55,6 +59,17 @@ $('document').ready(function() {
       var newContents = $(this).children('input[name=new-contents]').val();
       $(this).addClass('food-field');
       $(this).html(newContents);
+
+      // hacky way to prevent event bubbling from doing this stuff twice
+      if (hackyCounter % 2 == 0) {
+        deleteOldFoodFromFoods(foodNameToUpdate);
+
+        var newName = $(this).parent('tr').children('td.food-name').text();
+        var newCalories = $(this).parent('tr').children('td.food-calories').text();
+        updateLocalStorageFoods(newName, newCalories);
+        updateLocalStorageMealFoods(foodNameToUpdate, newName, newCalories);
+      }
+      hackyCounter++;
     });
   });
 
@@ -104,4 +119,31 @@ function generateErrors(name, calories) {
 function clearErrors() {
   $('#name-field .validation-error').empty();
   $('#calories-field .validation-error').empty();
+}
+
+function deleteOldFoodFromFoods(foodNameToUpdate) {
+  for (i = 0; i < foods.length; ++i) {
+    if (foods[i]["name"] == foodNameToUpdate) {
+      foods.remove(i);
+      break;
+    }
+  }
+}
+
+function updateLocalStorageFoods(newName, newCalories) {
+  var updatedFood = {name: newName, calories: newCalories}
+  foods.push(updatedFood);
+  localStorage.setItem('foodsList', JSON.stringify(foods));
+}
+
+function updateLocalStorageMealFoods(foodNameToUpdate, newName, newCalories) {
+  for (i=0; i < mealFoods.length; ++i) {
+    if (mealFoods[i]["name"] == foodNameToUpdate) {
+      var meal = mealFoods[i]["meal"];
+      mealFoods.remove(i);
+      var newMealFood = {name: newName, calories: newCalories, meal: meal};
+      mealFoods.push(newMealFood);
+      localStorage.setItem('mealFoodsList', JSON.stringify(mealFoods));
+    }
+  }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,3 @@
-var foods = JSON.parse(localStorage.getItem('foodsList')) || [];
-var mealFoods = JSON.parse(localStorage.getItem('mealFoodsList')) || [];
-
 $('document').ready(function() {
   displayDiaryFoods(foods);
   displayMealFoods(mealFoods);
@@ -31,9 +28,12 @@ $('document').ready(function() {
 
   $(document).on('click', '.food-delete', function() {
     var row = $(this).parent();
-    table = $(this).parents('table');
-    row.remove();
+    var foodNameToDelete = row.children('td.food-name').text();
+    var table = $(this).parents('table');
+    var mealNameToDelete = "." + table.attr('class');
 
+    row.remove();
+    deleteMealFoodFromLocalStorage(foodNameToDelete, mealNameToDelete);
     reloadTables(table);
   });
 });
@@ -170,6 +170,16 @@ function clearCheckBoxes() {
   $(":checked").prop('checked',false);
 
 };
+
+function deleteMealFoodFromLocalStorage(foodNameToDelete, mealNameToDelete) {
+  for (i = 0; i < mealFoods.length; ++i) {
+    if (mealFoods[i]["name"] == foodNameToDelete && mealFoods[i]["meal"] == mealNameToDelete) {
+      mealFoods.remove(i);
+      break;
+    }
+  }
+  localStorage.setItem('mealFoodsList', JSON.stringify(mealFoods));
+}
 
 function reloadTables(table) {
   calculateTotalMealCalories(table);


### PR DESCRIPTION
@neight-allen , can you check out what's happening below Line 63 in lib/foods.js?
I implemented a hacky solution that gets the job done for now, because I couldn't figure out how to prevent event bubbling from making the event fire twice. I looked at some docs on event.stopPropagation() but I wasn't able to get that to work.

@drod1000 , this PR does the following:
- persists food changes across refreshes
- updates the meal foods in the diary when a food is changed
- updates meal food local storage after deleting a food from the diary
- moves our local storage variables to common.js
